### PR TITLE
Allows ta-maxlength to be minified

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,22 @@
 
 Define maxlength for [textAngular](https://github.com/fraywing/textAngular)
 
-##Install
+## Install
 
 `bower install ta-maxlength`
 
-##Dependencies
+## Dependencies
 
  * jQuery (https://jquery.com/)
  * jquery-truncate-html (https://github.com/alexander-elgin/jquery-truncate-html)
 
-##Usage
+## Usage
 
-###Include the module in your app
+### Include the module in your app
 
 `angular.module('myApp',['ta-maxlength'])`
 
-###View
+### View
 
 `<text-angular ng-model="model" name="your-textAngular-instance-name" ta-maxlength="5">`
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ta-maxlength",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "homepage": "https://github.com/alexander-elgin/ta-maxlength",
   "authors": [
     "Alexander Elgin <sascha.elgin@gmail.com>"

--- a/ta-maxlength.js
+++ b/ta-maxlength.js
@@ -2,7 +2,7 @@
 
 angular
     .module('ta-maxlength', [])
-    .directive('taMaxlength', function ($timeout, textAngularManager) {
+    .directive('taMaxlength', ['$timeout', 'textAngularManager', function ($timeout, textAngularManager) {
         return {
             restrict: 'A',
             link: function ($scope, element, attrs) {
@@ -55,4 +55,4 @@ angular
                 });
             }
         };
-    });
+    }]);

--- a/ta-maxlength.js
+++ b/ta-maxlength.js
@@ -1,6 +1,8 @@
-'use strict';
+/* global $ */
+;(function () {
+    'use strict';
 
-angular
+    angular
     .module('ta-maxlength', [])
     .directive('taMaxlength', ['$timeout', 'textAngularManager', function ($timeout, textAngularManager) {
         return {
@@ -56,3 +58,4 @@ angular
             }
         };
     }]);
+}());


### PR DESCRIPTION
Hi @alexander-elgin!

We use this directive amongst our project but we have to face this issue in production:

```
vendor.1520808592048.js:1 Error: [$injector:unpr] Unknown provider: eProvider <- e <- taMaxlengthDirective
http://errors.angularjs.org/1.6.9/$injector/unpr?p0=eProvider%20%3C-%20e%20%3C-%20taMaxlengthDirective
    at vendor.1520808592048.js:1
    at vendor.1520808592048.js:1
    at Object.a [as get] (vendor.1520808592048.js:1)
    at vendor.1520808592048.js:1
    at a (vendor.1520808592048.js:1)
    at l (vendor.1520808592048.js:1)
    at Object.invoke (vendor.1520808592048.js:1)
    at vendor.1520808592048.js:1
    at x (vendor.1520808592048.js:1)
    at Object.<anonymous> (vendor.1520808592048.js:1)
```

So, in order to resolve it, we think to change the code in this way do the job.

In fact, it's because when the code is minified, `$timeout` and `textAngularManager` probably become `a` and `b` and the resolver not know anything like this.